### PR TITLE
fix: when exists path with spaces on windows directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const windowsScript = path.join(mainPath, './forWindows.vbs')
 const oloquinho = () => {
     const commandsForEachPlatform = {
       linux: `paplay ${soundPath}.ogg`,
-      win32: `${windowsScript} ${soundPath}.mp3`,
+      win32: `"${windowsScript}" "${soundPath}.mp3"`,
       darwin: `afplay ${soundPath}.mp3`,
     }
 


### PR DESCRIPTION
Exemple: C:\Users\JC Bombardelli\AppData\Roaming\npm\node_modules\oloquinho
This path break application