### PR TITLE
CI(Deploy): rodar o build apenas em tags na master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ deploy:
   api_key: $NPM_TOKEN
   on:
     tags: true
+    branches:
+      only:
+      - master


### PR DESCRIPTION
Previne que rode o CI em outros branchs sem ser master.